### PR TITLE
Fix image generation detection

### DIFF
--- a/src/oobabot/image_generator.py
+++ b/src/oobabot/image_generator.py
@@ -245,14 +245,14 @@ class ImageGenerator:
 
         self.image_verb_patterns = [
             re.compile(
-                r"^.*\b" + image_verb + r"\s*(an?|the)?\s*([\w ,\-\(\)\[\]=:]+)[^\w]*$",
+                r"^.*\b" + image_verb + r"\b\s*(an?|the)?\s*([\w ,\-\(\)\[\]=:]+)[^\w]*",
                 re.IGNORECASE,
             )
             for image_verb in self.image_verbs
         ]
         self.image_noun_patterns = [
             re.compile(
-                r"\b" + image_noun + r"\s*(as?|of|in|the|with)*\s*:?(.*)$",
+                r"\b" + image_noun + r"\s*(as?|of|in|the|with)*\s*:?\s*\b(.*)$",
                 re.IGNORECASE,
             )
             for image_noun in self.image_nouns


### PR DESCRIPTION
Fixes a bug I introduced to the image verb and noun regexes implemented in my last PR, where the capture groups don't properly account for word boundaries or spaces, leading to unintentional and/or garbled prompt contents.