### PR TITLE
Implement basic example dialogue support

### DIFF
--- a/src/oobabot/persona.py
+++ b/src/oobabot/persona.py
@@ -10,6 +10,7 @@ import typing
 import ruamel.yaml as ryaml
 
 from oobabot import fancy_logger
+from oobabot import templates
 
 
 class Persona:
@@ -27,7 +28,7 @@ class Persona:
 
     def __init__(self, persona_settings: dict) -> None:
         self.ai_name: str = persona_settings["ai_name"]
-        self.persona: str = persona_settings["persona"]
+        self.persona: str = persona_settings["persona"].replace(str(templates.TemplateToken.AI_NAME), self.ai_name)
         self.wakewords: typing.List[str] = persona_settings["wakewords"].copy()
 
         # if a json file is specified, load it and have

--- a/src/oobabot/settings.py
+++ b/src/oobabot/settings.py
@@ -300,7 +300,8 @@ class Settings:
                         bot to play.  Alternatively, this can be set with the
                         {self.OOBABOT_PERSONA_ENV_VAR} environment variable.
                         """
-                    )
+                    ),
+                    _make_template_comment(([templates.TemplateToken.AI_NAME], "", True))[2],
                 ],
                 show_default_in_yaml=False,
             )

--- a/src/oobabot/templates.py
+++ b/src/oobabot/templates.py
@@ -26,6 +26,8 @@ class Templates(enum.Enum):
 
     # prompts to the AI to generate text responses
     PROMPT = "prompt"
+    EXAMPLE_DIALOGUE = "example_dialogue"
+    SECTION_SEPARATOR = "section_separator"
     PROMPT_HISTORY_LINE = "prompt_history_line"
     PROMPT_IMAGE_COMING = "prompt_image_coming"
 
@@ -46,7 +48,9 @@ class TemplateToken(str, enum.Enum):
     PERSONA = "PERSONA"
     IMAGE_COMING = "IMAGE_COMING"
     IMAGE_PROMPT = "IMAGE_PROMPT"
+    EXAMPLE_DIALOGUE = "EXAMPLE_DIALOGUE"
     MESSAGE_HISTORY = "MESSAGE_HISTORY"
+    SECTION_SEPARATOR = "SECTION_SEPARATOR"
     USER_MESSAGE = "USER_MESSAGE"
     USER_NAME = "USER_NAME"
     GUILDNAME = "GUILDNAME"
@@ -81,6 +85,7 @@ class TemplateStore:
                 TemplateToken.AI_NAME,
                 TemplateToken.IMAGE_COMING,
                 TemplateToken.MESSAGE_HISTORY,
+                TemplateToken.SECTION_SEPARATOR,
                 TemplateToken.PERSONA,
                 TemplateToken.CHANNELNAME,
                 TemplateToken.GUILDNAME,
@@ -88,6 +93,23 @@ class TemplateStore:
             "The main prompt sent to Oobabooga to generate a response from "
             + "the bot AI.  The AI's reply to this prompt will be sent to "
             + "discord as the bot's response.",
+            True,
+        ),
+        Templates.EXAMPLE_DIALOGUE: (
+            [
+                TemplateToken.AI_NAME,
+            ],
+            "The example dialogue inserted directly before the message history. "
+            + "This is gradually pushed out as the chat grows beyond the context "
+            + "length in the same as as the message history itself.",
+            True,
+        ),
+        Templates.SECTION_SEPARATOR: (
+            [
+                TemplateToken.AI_NAME,
+            ],
+            "Separator between different sections, if necessary. For example, to "
+            "separate example dialogue from the main chat transcript.",
             True,
         ),
         Templates.PROMPT_HISTORY_LINE: (
@@ -163,6 +185,12 @@ class TemplateStore:
             {MESSAGE_HISTORY}
             {IMAGE_COMING}
             """
+        ),
+        Templates.EXAMPLE_DIALOGUE: textwrap.dedent(
+            ""
+        ),
+        Templates.SECTION_SEPARATOR: textwrap.dedent(
+            "***"
         ),
         Templates.PROMPT_HISTORY_LINE: textwrap.dedent(
             """


### PR DESCRIPTION
- The example dialogue is configured separately to the main prompt and supports templating
- The example dialogue is added line by line up to the history limit, filling the free space that the chat transcript has
- Lines are pushed out one by one as the history limit is approached, yielding to chat transcript lines

This can help with consistency and coherence if the channel is empty or the bot has just been /lobotomized

Also added a crude templating of the AI name into the persona string. I don't like the way that's done but the current organizational structure and schema makes it challenging to implement any other way. We may need to consider a refactor in future to enable more flexibility.

Next thing I want to implement is an embedding database to enable long-term memory support..... but I'm not sure how well that sits with the Discord ToS, so it'll absolutely be an optional and off-by-default feature.