### PR TITLE
updated /stop bot command to use latest API call

### DIFF
--- a/src/oobabot/bot_commands.py
+++ b/src/oobabot/bot_commands.py
@@ -37,6 +37,7 @@ class BotCommands:
         self.persona = persona
         self.reply_in_thread = discord_settings["reply_in_thread"]
         self.template_store = template_store
+        self.ooba_client = ooba_client
 
         (
             self.discrivener_location,
@@ -123,8 +124,9 @@ class BotCommands:
             if interaction.channel_id is None:
                 await discord_utils.fail_interaction(interaction)
                 return
-            response = await ooba_client.OobaClient.stop()
-            await interaction.response.send_message(response)
+            response = await self.ooba_client.stop()
+            str_response = response if response is not None else "No response from server."
+            await interaction.response.send_message(str_response)
             return
 
         @discord.app_commands.command(

--- a/src/oobabot/ooba_client.py
+++ b/src/oobabot/ooba_client.py
@@ -136,7 +136,7 @@ class OobaClient(http_client.SerializedHttpClient):
     SERVICE_NAME = "Oobabooga"
 
     OOBABOOGA_STREAMING_URI_PATH: str = "/api/v1/stream"
-    OOBABOOGA_STOP_STREAM_URI_PATH: str = "/api/v1/stop-stream"
+    OOBABOOGA_STOP_STREAM_URI_PATH: str = "/v1/internal/stop-generation"
 
     def __init__(
         self,
@@ -234,19 +234,15 @@ class OobaClient(http_client.SerializedHttpClient):
             last_response = time.perf_counter()
 
     async def stop(self):
-        if self.use_openai:
-             
-            pass
-        else:
-            # Existing Ooba API stopping logic
-            async with aiohttp.ClientSession() as session:
-                url = f"{self.base_blocking}{self.OOBABOOGA_STOP_STREAM_URI_PATH}"
-                headers = {"Content-Type": "application/json"}
+        # New Ooba OpenAPI stopping logic
+        async with aiohttp.ClientSession() as session:
+            url = f"{self.base_blocking}{self.OOBABOOGA_STOP_STREAM_URI_PATH}"
+            headers = {"accept": "application/json"}
 
-                async with session.post(url, data=json.dumps({}), headers=headers) as response:
-                   response_text = await response.text()
-                   print(response_text)
-                   return response_text
+            async with session.post(url, data=json.dumps({}), headers=headers) as response:
+               response_text = await response.text()
+               print(response_text)
+               return response_text
     async def request_by_token(self, prompt: str) -> typing.AsyncIterator[str]:
         """
         Yields each token of the response as it arrives.

--- a/src/oobabot/voice_client.py
+++ b/src/oobabot/voice_client.py
@@ -23,6 +23,7 @@ from oobabot import ooba_client  # pylint: disable=unused-import
 from oobabot import prompt_generator  # pylint: disable=unused-import
 from oobabot import transcript
 from oobabot import types
+from oobabot import persona
 
 
 class VoiceClientError(Exception):
@@ -49,6 +50,7 @@ class VoiceClient(discord.VoiceProtocol):
     current_instance: typing.Optional["VoiceClient"] = None
     ooba_client: ooba_client.OobaClient
     prompt_generator: prompt_generator.PromptGenerator
+    persona: persona.Persona
     wakewords: typing.List[str] = []
 
     supported_modes: typing.Tuple[voice.SupportedModes, ...] = (


### PR DESCRIPTION
Small change to include the updated API post url and header so the /stop command functions correctly. 

Correct response from the server should just be "OK" and the discord message will reflect that. Otherwise the /stop command will respond with "No response from server." Previously a failed attempt would result in errors for trying to send an empty message.

I also updated the voice_client.py to include some missing dependencies.